### PR TITLE
fix(auth): handle duplicate email on registration

### DIFF
--- a/src/main/java/com/github/nathandekeyrel/kismet/UserController.java
+++ b/src/main/java/com/github/nathandekeyrel/kismet/UserController.java
@@ -25,7 +25,11 @@ public class UserController {
     }
 
     @PostMapping("/register")
-    public String processRegistration(@ModelAttribute("user") User user) {
+    public String processRegistration(User user, Model model) {
+        if (userRepository.findByEmail(user.getEmail()).isPresent()) {
+            model.addAttribute("error", "An account with this email already exists.");
+            return "register";
+        }
         user.setPassword(passwordEncoder.encode(user.getPassword()));
         userRepository.save(user);
         return "redirect:/login";

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -26,6 +26,6 @@
         <button type="submit">Log In</button>
     </div>
 </form>
-
+<p>Don't have an account? <a th:href="@{/register}">Register here.</a></p>
 </body>
 </html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -5,6 +5,10 @@
 </head>
 <body>
 <h1>Create an Account</h1>
+<div th:if="${error}" class="error-message">
+    <p th:text="${error}"></p>
+</div>
+
 <form th:action="@{/register}" th:object="${user}" method="post">
     <div>
         <label>Email:</label>
@@ -18,5 +22,6 @@
         <button type="submit">Register</button>
     </div>
 </form>
+<p>Already have an account? <a th:href="@{/login}">Log in here.</a></p>
 </body>
 </html>

--- a/src/test/java/com/github/nathandekeyrel/kismet/UserControllerTest.java
+++ b/src/test/java/com/github/nathandekeyrel/kismet/UserControllerTest.java
@@ -8,8 +8,15 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Optional;
+
 import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -36,5 +43,30 @@ public class UserControllerTest {
         mockMvc.perform(get("/"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("http://localhost/login"));
+    }
+
+    @Test
+    void whenRegisteringNewUser_thenSavesUserAndRedirectsToLogin() throws Exception {
+        mockMvc.perform(post("/register")
+                .param("email", "newuser@example.com")
+                .param("password", "12345")
+                .with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/login"));
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void whenRegisteringDuplicateUser_thenReturnsRegisterPageWithError() throws Exception {
+        String duplicateEmail = "test@example.com";
+        when(userRepository.findByEmail(duplicateEmail)).thenReturn(Optional.of(new User()));
+
+        mockMvc.perform(post("/register")
+                        .param("email", duplicateEmail)
+                        .param("password", "12345")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(view().name("register"))
+                .andExpect(model().attributeExists("error"));
     }
 }


### PR DESCRIPTION
Trying to register with an email that is already registered now notifies the user.
Also added links register->login and login->register to handle cases where users already have an account or don't have one yet