### PR TITLE
feat(matching): implement match creation logic and tests

### DIFF
--- a/src/main/java/com/github/nathandekeyrel/kismet/config/SecurityConfig.java
+++ b/src/main/java/com/github/nathandekeyrel/kismet/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
             )
             .formLogin(form -> form
                     .loginPage("/login")
-                    .defaultSuccessUrl("/", true)
+                    .defaultSuccessUrl("/home", true)
                     .permitAll()
             )
             .logout(logout -> logout

--- a/src/main/java/com/github/nathandekeyrel/kismet/matching/MatchController.java
+++ b/src/main/java/com/github/nathandekeyrel/kismet/matching/MatchController.java
@@ -6,6 +6,8 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.security.Principal;
 import java.util.Optional;
@@ -30,6 +32,30 @@ public class MatchController {
         potentialMatch.ifPresent(user -> model.addAttribute("potentialMatch", user));
 
         return "home";
+    }
+
+    @PostMapping("/home/like")
+    public String likeUser(@RequestParam Long targetId, Principal principal) {
+        User currentUser = userRepository.findByEmail(principal.getName())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        User targetUser = userRepository.findById(targetId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        matchService.recordAction(currentUser, targetUser, ActionType.LIKE);
+
+        return "redirect:/home";
+    }
+
+    @PostMapping("/home/pass")
+    public String passUser(@RequestParam Long targetId, Principal principal) {
+        User currentUser = userRepository.findByEmail(principal.getName())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        User targetUser = userRepository.findById(targetId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        matchService.recordAction(currentUser, targetUser, ActionType.PASS);
+
+        return "redirect:/home";
     }
 
 }

--- a/src/main/java/com/github/nathandekeyrel/kismet/matching/MutualMatchRepository.java
+++ b/src/main/java/com/github/nathandekeyrel/kismet/matching/MutualMatchRepository.java
@@ -2,9 +2,15 @@ package com.github.nathandekeyrel.kismet.matching;
 
 import com.github.nathandekeyrel.kismet.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MutualMatchRepository extends JpaRepository<MutualMatch, Long> {
     List<MutualMatch> findByUser1OrUser2(User user1, User user2);
+
+    @Query("SELECT m FROM MutualMatch m WHERE (m.user1 = :user1 AND m.user2 = :user2) OR (m.user1 = :user2 AND m.user2 = :user1)")
+    Optional<MutualMatch> findMatchBetween(@Param("user1") User user1, @Param("user2") User user2);
 }

--- a/src/main/java/com/github/nathandekeyrel/kismet/user/UserRepository.java
+++ b/src/main/java/com/github/nathandekeyrel/kismet/user/UserRepository.java
@@ -11,8 +11,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     List<User> findByFirstNameContainingIgnoreCaseOrLastNameContainingIgnoreCase(String firstName, String lastName);
 
-    @Query(value = "SELECT * FROM users WHERE user.id != :currentUserId AND user.id NOT IN " +
+    @Query(value = "SELECT * FROM users u WHERE u.id != :currentUserId AND u.id NOT IN " +
                    "(SELECT ma.target_id FROM match_actions ma WHERE ma.actor_id = :currentUserId) " +
-                   "ORDER BY RANDOM() LIMIT 1",  nativeQuery = true)
+                   "ORDER BY RANDOM() LIMIT 1", nativeQuery = true)
     Optional<User> findRandomUserNotInteractedWith(@Param("currentUserId") Long currentUserId);
 }

--- a/src/test/java/com/github/nathandekeyrel/kismet/matching/MatchServiceTest.java
+++ b/src/test/java/com/github/nathandekeyrel/kismet/matching/MatchServiceTest.java
@@ -4,6 +4,7 @@ import com.github.nathandekeyrel.kismet.user.User;
 import com.github.nathandekeyrel.kismet.user.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,6 +20,12 @@ public class MatchServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private MatchActionRepository matchActionRepository;
+
+    @Mock
+    private MutualMatchRepository mutualMatchRepository;
 
     @InjectMocks
     private MatchService matchService;
@@ -39,5 +46,73 @@ public class MatchServiceTest {
         assertEquals(expectedMatch, actualMatch.get());
 
         verify(userRepository, times(1)).findRandomUserNotInteractedWith(1L);
+    }
+
+    @Test
+    void recordAction_whenActionIsPass_thenSavesPassAction() {
+        User actor = new User();
+        actor.setId(1L);
+        User target = new User();
+        target.setId(2L);
+
+        ArgumentCaptor<MatchAction> matchActionCaptor = ArgumentCaptor.forClass(MatchAction.class);
+
+        matchService.recordAction(actor, target, ActionType.PASS);
+
+        verify(matchActionRepository, times(1)).save(matchActionCaptor.capture());
+
+        MatchAction savedAction = matchActionCaptor.getValue();
+        assertEquals(actor, savedAction.getUser());
+        assertEquals(target, savedAction.getTarget());
+        assertEquals(ActionType.PASS, savedAction.getAction());
+
+        verify(mutualMatchRepository, never()).save(any(MutualMatch.class));
+    }
+
+    @Test
+    void recordAction_whenActionIsLikeAndNoMutualMatch_thenSavesLikeAndChecks() {
+        User actor = new User();
+        actor.setId(1L);
+        User target = new User();
+        target.setId(2L);
+
+        ArgumentCaptor<MatchAction> matchActionCaptor = ArgumentCaptor.forClass(MatchAction.class);
+
+        when(matchActionRepository.findByUserAndTarget(target, actor)).thenReturn(Optional.empty());
+
+        matchService.recordAction(actor, target, ActionType.LIKE);
+
+        verify(matchActionRepository, times(1)).save(matchActionCaptor.capture());
+        assertEquals(ActionType.LIKE, matchActionCaptor.getValue().getAction());
+
+        verify(matchActionRepository, times(1)).findByUserAndTarget(target, actor);
+
+        verify(mutualMatchRepository, never()).save(any(MutualMatch.class));
+    }
+
+    @Test
+    void recordAction_whenActionIsLikeAndMutualMatchExists_thenSavesLikeAndCreatesMutualMatch() {
+        User actor = new User();
+        actor.setId(1L);
+        User target = new User();
+        target.setId(2L);
+
+        ArgumentCaptor<MutualMatch> mutualMatchCaptor = ArgumentCaptor.forClass(MutualMatch.class);
+
+        MatchAction otherUsersLikeAction = new MatchAction();
+        otherUsersLikeAction.setUser(target);
+        otherUsersLikeAction.setTarget(actor);
+        otherUsersLikeAction.setAction(ActionType.LIKE);
+        when(matchActionRepository.findByUserAndTarget(target, actor)).thenReturn(Optional.of(otherUsersLikeAction));
+
+        matchService.recordAction(actor, target, ActionType.LIKE);
+
+        verify(matchActionRepository, times(1)).findByUserAndTarget(target, actor);
+
+        verify(mutualMatchRepository, times(1)).save(mutualMatchCaptor.capture());
+
+        MutualMatch savedMutualMatch = mutualMatchCaptor.getValue();
+        assertEquals(actor, savedMutualMatch.getUser1());
+        assertEquals(target, savedMutualMatch.getUser2());
     }
 }


### PR DESCRIPTION
Implement match creation logic, allowing users to like or pass on another user
Fix users not being able to see a potential match on  the match deck
Fix login redirect endpoint not going to `/home`
Add tests for match logic and endpoints